### PR TITLE
docs: add more detailed help messages and update `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,58 +20,45 @@ brew install znscli/tap/zns
 ## Usage
 
 ```sh
-$ zns google.com
-A       google.com.    04m05s       142.251.39.110
-AAAA    google.com.    04m07s       2a00:1450:400e:802::200e
-MX      google.com.    03m32s       10  smtp.google.com.
-NS      google.com.    93h48m24s    ns2.google.com.
-NS      google.com.    93h48m24s    ns3.google.com.
-NS      google.com.    93h48m24s    ns4.google.com.
-NS      google.com.    93h48m24s    ns1.google.com.
-SOA     google.com.    55s          ns1.google.com. dns-admin.google.com.
+$ zns example.com
+A	    example.com.	44m45s	93.184.215.14
+NS	  example.com.	21h07m52s	a.iana-servers.net.
+NS	  example.com.	21h07m52s	b.iana-servers.net.
+SOA	  example.com.	01h00m00s	ns.icann.org. noc.dns.icann.org.
+MX	  example.com.	23h13m58s	0 .
+TXT	  example.com.	21h49m03s	v=spf1 -all
+TXT	  example.com.	21h49m03s wgyf8z8cgvm2qmxpnbnldrcltvk4xqfn
+AAAA	example.com.	09m35s	2606:2800:21f:cb07:6820:80da:af6b:8b2c
 ```
 
 ### Query a specific record type
 
 ```sh
-$ zns google.com -q NS
-NS      google.com.    93h48m24s    ns2.google.com.
-NS      google.com.    93h48m24s    ns3.google.com.
-NS      google.com.    93h48m24s    ns4.google.com.
-NS      google.com.    93h48m24s    ns1.google.com.
+$ zns example.com -q NS
+NS	example.com.	19h27m03s	a.iana-servers.net.
+NS	example.com.	19h27m03s	b.iana-servers.net.
 ```
 
 ### Use a specific DNS server
 
 ```sh
-$ zns google.com -q NS --server 1.1.1.1
-NS      google.com.    93h48m24s    ns2.google.com.
-NS      google.com.    93h48m24s    ns3.google.com.
-NS      google.com.    93h48m24s    ns4.google.com.
-NS      google.com.    93h48m24s    ns1.google.com.
+$ zns example.com -q NS --server 1.1.1.1
+NS	example.com.	19h27m03s	a.iana-servers.net.
+NS	example.com.	19h27m03s	b.iana-servers.net.
 ```
 
 ### JSON output
 
 ```sh
-$ zns google.com --json | jq
+$ zns example.com --json -q A | jq
 {
-  "@domain": "google.com",
+  "@domain": "example.com",
   "@level": "info",
-  "@record": "142.250.179.206",
-  "@timestamp": "2024-11-26T12:48:01.400203+01:00",
-  "@ttl": "04m02s",
+  "@message": "Successful query",
+  "@record": "93.184.215.14",
+  "@timestamp": "2024-11-27T21:33:52.689673+01:00",
+  "@ttl": "28m50s",
   "@type": "A",
-  "@version": "dev",
-  "@view": "json"
-},
-{
-  "@domain": "google.com",
-  "@level": "info",
-  "@record": "ns2.google.com.",
-  "@timestamp": "2024-11-26T12:48:01.401724+01:00",
-  "@ttl": "93h46m51s",
-  "@type": "NS",
   "@version": "dev",
   "@view": "json"
 }
@@ -82,7 +69,7 @@ $ zns google.com --json | jq
 
 ```sh
 export ZNS_LOG_FILE=/tmp/zns.log
-$ zns google.com
+$ zns example.com
 ```
 
 ## Contributing

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,8 +26,26 @@ var (
 	qtype  string
 
 	rootCmd = &cobra.Command{
-		Use:     "zns",
-		Short:   "zns - foobar",
+		Use:   "zns",
+		Short: "zns is a command-line utility for querying DNS records and displaying them in human- or machine-readable formats.",
+		Long:  "zns is a command-line utility for querying DNS records, displaying them in a human-readable, colored format that includes type, name, TTL, and value. It supports various DNS record types, concurrent queries for improved performance, JSON output format for machine-readable results, and options to write output to a file or query a specific DNS server.",
+		Example: `
+  # Query DNS records for example.com
+  zns example.com
+
+  # Query a specific record type
+  zns example.com -q NS
+
+  # Use a specific DNS server
+  zns example.com -q NS --server 1.1.1.1
+
+  # JSON output
+  zns example.com --json | jq
+
+  # Writing to a file
+  export ZNS_LOG_FILE=/tmp/zns.log
+  zns example.com
+`,
 		Version: version,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) != 1 {


### PR DESCRIPTION
Adds longer, more detailed explanations to the output of `zns -h` and `zns --help`.

Changes references from `google.com` to `example.com`, as `example.com` is made for use in documentation and is more neutral. See [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606)

Closes #8 