### PR TITLE
ci: add basic ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build binary
+        run: go build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # zns
 
+![CI](https://github.com/znscli/zns/actions/workflows/ci.yaml/badge.svg?branch=main)
+
 zns is a command-line utility for querying DNS records, displaying them in a human-readable, colored format that includes type, name, TTL, and value.
 
 ## Features


### PR DESCRIPTION
Adds basic CI workflow ran for every PR and commits pushed to `main`.
To be expanded as required.

Closes #14 