### PR TITLE
feat: add tabular output to `HumanRenderer`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -149,9 +149,10 @@ var (
 
 			for _, m := range messages {
 				for _, record := range m.Answer {
-					v.Render(args[0], record)
+					v.AddRecord(args[0], record)
 				}
 			}
+			v.Render()
 		},
 	}
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/jedib0t/go-pretty/v6 v6.6.4
 	github.com/miekg/dns v1.1.62
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0
@@ -18,7 +19,9 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/net v0.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jedib0t/go-pretty/v6 v6.6.4 h1:B51RjA+Sytv0C0Je7PHGDXZBF2JpS5dZEWWRueBLP6U=
+github.com/jedib0t/go-pretty/v6 v6.6.4/go.mod h1:zbn98qrYlh95FIhwwsbIip0LYpwSG8SUOScs+v9/t0E=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -24,10 +26,14 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=
 github.com/miekg/dns v1.1.62/go.mod h1:mvDlcItzm+br7MToIKqkglaGhlFMHJ9DTNNWONWXbNQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=

--- a/internal/view/format.go
+++ b/internal/view/format.go
@@ -59,41 +59,38 @@ func formatRecordAsJSON(domain string, answer dns.RR) map[string]interface{} {
 	return m
 }
 
-// formatRecord generates a human-readable string representing a DNS record with colors.
-func formatRecord(domainName string, answer dns.RR) string {
+// formatRecord generates human-readable strings representing a DNS record with colors.
+func formatRecord(domain string, answer dns.RR) []interface{} {
 	recordType := color.HiYellowString(dns.TypeToString[answer.Header().Rrtype])
 	formattedTTL := color.HiMagentaString(formatTTL(answer.Header().Ttl))
 
 	switch rec := answer.(type) {
 	case *dns.A:
-		return fmt.Sprintf("%s\t%s.\t%s\t%s", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.A.String()))
+		return []interface{}{recordType, color.HiBlueString(domain), formattedTTL, color.HiWhiteString(rec.A.String())}
 	case *dns.AAAA:
-		return fmt.Sprintf("%s\t%s.\t%s\t%s", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.AAAA.String()))
+		return []interface{}{recordType, color.HiBlueString(domain), formattedTTL, color.HiWhiteString(rec.AAAA.String())}
 	case *dns.CNAME:
-		return fmt.Sprintf("%s\t%s.\t%s\t%s", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.Target))
+		return []interface{}{recordType, color.HiBlueString(domain), formattedTTL, color.HiWhiteString(rec.Target)}
 	case *dns.MX:
 		preference := color.HiRedString(strconv.FormatUint(uint64(rec.Preference), 10))
-		return fmt.Sprintf("%s\t%s.\t%s\t%s %s", recordType, color.HiBlueString(domainName), formattedTTL, preference, color.HiWhiteString(rec.Mx))
+		return []interface{}{recordType, color.HiBlueString(domain), formattedTTL, preference, color.HiWhiteString(rec.Mx)}
 	case *dns.TXT:
 		txtJoined := strings.Join(rec.Txt, " ")
-		return fmt.Sprintf("%s\t%s.\t%s\t%s", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(txtJoined))
+		return []interface{}{recordType, color.HiBlueString(domain), formattedTTL, color.HiWhiteString(txtJoined)}
 	case *dns.NS:
-		return fmt.Sprintf("%s\t%s.\t%s\t%s", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.Ns))
+		return []interface{}{recordType, color.HiBlueString(domain), formattedTTL, color.HiWhiteString(rec.Ns)}
 	case *dns.SOA:
 		primaryNameServer := color.HiRedString(rec.Ns)
-		return fmt.Sprintf("%s\t%s.\t%s\t%s %s", recordType, color.HiBlueString(domainName), formattedTTL, primaryNameServer, color.HiWhiteString(rec.Mbox))
+		return []interface{}{recordType, color.HiBlueString(domain), formattedTTL, primaryNameServer, color.HiWhiteString(rec.Mbox)}
 	case *dns.PTR:
-		return fmt.Sprintf("%s\t%s.\t%s\t%s", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.Ptr))
+		return []interface{}{recordType, color.HiBlueString(domain), formattedTTL, color.HiWhiteString(rec.Ptr)}
 	default:
-		return fmt.Sprintf(`
-Unknown record type: %s
-
-We encountered an unsupported DNS record type: %s. 
-Please consider raising an issue on GitHub to add support for this record type.
-
-https://github.com/znscli/zns/issues/new
-
-Thank you for your contribution!
-`, recordType, recordType)
+		return []interface{}{fmt.Sprintf(`
+		Unknown record type: %s
+		Please consider raising an issue on GitHub
+		to add support for this record type.
+		https://github.com/znscli/zns/issues/new
+		Thank you for your contribution!
+		`, recordType)}
 	}
 }

--- a/internal/view/format_test.go
+++ b/internal/view/format_test.go
@@ -182,7 +182,7 @@ func TestFormatRecord(t *testing.T) {
 		os.Setenv("NO_COLOR", "true") // Disable colors for easier testing
 
 		r := formatRecord(domain, record)
-		assert.Equal(t, "A\texample.com.\t03m42s\t127.0.0.1", r)
+		assert.Equal(t, []interface{}{"A", "example.com", "03m42s", "127.0.0.1"}, r)
 	})
 
 	t.Run("CNAME record", func(t *testing.T) {
@@ -198,7 +198,7 @@ func TestFormatRecord(t *testing.T) {
 		}
 
 		r := formatRecord(domain, record)
-		assert.Equal(t, "CNAME\texample.com.\t08m20s\texample.com.", r)
+		assert.Equal(t, []interface{}{"CNAME", "example.com", "08m20s", "example.com."}, r)
 	})
 
 	t.Run("MX record", func(t *testing.T) {
@@ -215,7 +215,7 @@ func TestFormatRecord(t *testing.T) {
 		}
 
 		r := formatRecord(domain, record)
-		assert.Equal(t, "MX\texample.com.\t08m20s\t10 example.com.", r)
+		assert.Equal(t, []interface{}{"MX", "example.com", "08m20s", "10", "example.com."}, r)
 	})
 
 	t.Run("SOA record", func(t *testing.T) {
@@ -232,7 +232,7 @@ func TestFormatRecord(t *testing.T) {
 		}
 
 		r := formatRecord(domain, record)
-		assert.Equal(t, "SOA\texample.com.\t08m20s\texample.com. hostmaster.example.com.", r)
+		assert.Equal(t, []interface{}{"SOA", "example.com", "08m20s", "example.com.", "hostmaster.example.com."}, r)
 	})
 
 	t.Run("Unknown record type", func(t *testing.T) {
@@ -248,6 +248,6 @@ func TestFormatRecord(t *testing.T) {
 		}
 
 		r := formatRecord(domain, record)
-		assert.Contains(t, r, "Unknown record type")
+		assert.Contains(t, r[0].(string), "Unknown record type")
 	})
 }

--- a/internal/view/render_test.go
+++ b/internal/view/render_test.go
@@ -57,9 +57,10 @@ func TestNewHumanRenderer_Render(t *testing.T) {
 			A: net.IPv4(127, 0, 0, 1),
 		}
 
-		hr.Render(domain, record)
+		hr.AddRecord(domain, record)
+		hr.Render()
 
-		want := "A\texample.com.\t03m42s\t127.0.0.1\n"
+		want := " A  example.com  03m42s  127.0.0.1 \n"
 
 		assert.Equal(t, want, b.String())
 	})
@@ -94,11 +95,12 @@ func TestNewHumanRenderer_Render(t *testing.T) {
 		}
 
 		for _, record := range records {
-			hr.Render(domain, record)
+			hr.AddRecord(domain, record)
 		}
+		hr.Render()
 
-		want := "A\texample.com.\t03m42s\t127.0.0.1\n" +
-			"AAAA\texample.com.\t03m42s\t2001:db8::1\n"
+		want := " A     example.com  03m42s  127.0.0.1   \n" +
+			" AAAA  example.com  03m42s  2001:db8::1 \n"
 
 		assert.Equal(t, want, b.String())
 	})
@@ -150,7 +152,7 @@ func TestNewJSONRenderer_Render(t *testing.T) {
 			A: net.IPv4(127, 0, 0, 1),
 		}
 
-		jr.Render(domain, record)
+		jr.AddRecord(domain, record)
 
 		want := []map[string]interface{}{
 			{
@@ -197,7 +199,7 @@ func TestNewJSONRenderer_Render(t *testing.T) {
 		}
 
 		for _, record := range records {
-			jr.Render(domain, record)
+			jr.AddRecord(domain, record)
 		}
 
 		want := []map[string]interface{}{


### PR DESCRIPTION
Introduces `go-pretty/v6/table` to keep human readable output aligned without tedious use of `fmt.Sprintf()`, previously found in `formatRecord()`.

Additionally updates the `Renderer` interface as table rows need to be submitted before writing them to stdout.

Fixes #11 