### PR TITLE
Fix flaky tab writing behavior using text/tabwriter

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,7 +73,7 @@ var (
 				vt = arguments.ViewHuman
 			}
 
-			var w = view.NewTabWriter(os.Stdout)
+			var w = view.NewTabWriter(os.Stdout, debug)
 			logFile := os.Getenv("ZNS_LOG_FILE")
 			if logFile != "" {
 				f, err := os.Create(logFile)
@@ -81,7 +81,7 @@ var (
 					panic(fmt.Sprintf("Failed to create log file: %v", err))
 				}
 				defer f.Close()
-				w = view.NewTabWriter(f)
+				w = view.NewTabWriter(f, debug)
 			}
 
 			v := view.NewRenderer(vt, &view.View{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"sort"
 	"strings"
@@ -74,7 +73,7 @@ var (
 				vt = arguments.ViewHuman
 			}
 
-			var w io.Writer = os.Stdout
+			var w = view.NewTabWriter(os.Stdout)
 			logFile := os.Getenv("ZNS_LOG_FILE")
 			if logFile != "" {
 				f, err := os.Create(logFile)
@@ -82,7 +81,7 @@ var (
 					panic(fmt.Sprintf("Failed to create log file: %v", err))
 				}
 				defer f.Close()
-				w = f
+				w = view.NewTabWriter(f)
 			}
 
 			v := view.NewRenderer(vt, &view.View{
@@ -152,6 +151,7 @@ var (
 					v.Render(args[0], record)
 				}
 			}
+			w.Flush() // we need to flush the buffer to ensure all data is written to the underlying stream.
 		},
 	}
 )

--- a/internal/view/format.go
+++ b/internal/view/format.go
@@ -85,24 +85,24 @@ func formatRecord(domainName string, answer dns.RR) string {
 
 	switch rec := answer.(type) {
 	case *dns.A:
-		return fmt.Sprintf("%s\t%s.\t%s\t%s\n", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.A.String()))
+		return fmt.Sprintf("%s\t%s.\t%s\t%s", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.A.String()))
 	case *dns.AAAA:
-		return fmt.Sprintf("%s\t%s.\t%s\t%s\n", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.AAAA.String()))
+		return fmt.Sprintf("%s\t%s.\t%s\t%s", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.AAAA.String()))
 	case *dns.CNAME:
-		return fmt.Sprintf("%s\t%s.\t%s\t%s\n", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.Target))
+		return fmt.Sprintf("%s\t%s.\t%s\t%s", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.Target))
 	case *dns.MX:
 		preference := color.HiRedString(strconv.FormatUint(uint64(rec.Preference), 10))
-		return fmt.Sprintf("%s\t%s.\t%s\t%s %s\n", recordType, color.HiBlueString(domainName), formattedTTL, preference, color.HiWhiteString(rec.Mx))
+		return fmt.Sprintf("%s\t%s.\t%s\t%s %s", recordType, color.HiBlueString(domainName), formattedTTL, preference, color.HiWhiteString(rec.Mx))
 	case *dns.TXT:
 		txtJoined := strings.Join(rec.Txt, " ")
-		return fmt.Sprintf("%s\t%s.\t%s\t%s\n", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(txtJoined))
+		return fmt.Sprintf("%s\t%s.\t%s\t%s", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(txtJoined))
 	case *dns.NS:
-		return fmt.Sprintf("%s\t%s.\t%s\t%s\n", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.Ns))
+		return fmt.Sprintf("%s\t%s.\t%s\t%s", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.Ns))
 	case *dns.SOA:
 		primaryNameServer := color.HiRedString(rec.Ns)
-		return fmt.Sprintf("%s\t%s.\t%s\t%s %s\n", recordType, color.HiBlueString(domainName), formattedTTL, primaryNameServer, color.HiWhiteString(rec.Mbox))
+		return fmt.Sprintf("%s\t%s.\t%s\t%s %s", recordType, color.HiBlueString(domainName), formattedTTL, primaryNameServer, color.HiWhiteString(rec.Mbox))
 	case *dns.PTR:
-		return fmt.Sprintf("%s\t%s.\t%s\t%s\n", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.Ptr))
+		return fmt.Sprintf("%s\t%s.\t%s\t%s", recordType, color.HiBlueString(domainName), formattedTTL, color.HiWhiteString(rec.Ptr))
 	default:
 		return fmt.Sprintf(`
 Unknown record type: %s

--- a/internal/view/format.go
+++ b/internal/view/format.go
@@ -12,7 +12,9 @@ import (
 	"github.com/miekg/dns"
 )
 
-// NewTabWriter creates and initializes a tabwriter.Writer.
+// NewTabWriter initializes and returns a new tabwriter.Writer.
+// ZNS uses this writer to format DNS records into a clear, human-readable table.
+// See https://pkg.go.dev/text/tabwriter#Writer.Init for details.
 func NewTabWriter(w io.Writer) *tabwriter.Writer {
 	return tabwriter.NewWriter(
 		w,

--- a/internal/view/format.go
+++ b/internal/view/format.go
@@ -52,6 +52,7 @@ func formatRecordAsJSON(domain string, answer dns.RR) map[string]interface{} {
 	m["@type"] = dns.TypeToString[answer.Header().Rrtype]
 	m["@ttl"] = formatTTL(answer.Header().Ttl)
 
+	// Add specific fields depending on the record type
 	switch rec := answer.(type) {
 	case *dns.A:
 		m["@record"] = rec.A.String()

--- a/internal/view/format.go
+++ b/internal/view/format.go
@@ -15,14 +15,18 @@ import (
 // NewTabWriter initializes and returns a new tabwriter.Writer.
 // ZNS uses this writer to format DNS records into a clear, human-readable table.
 // See https://pkg.go.dev/text/tabwriter#Writer.Init for details.
-func NewTabWriter(w io.Writer) *tabwriter.Writer {
+func NewTabWriter(w io.Writer, debug bool) *tabwriter.Writer {
+	flags := uint(0)
+	if debug {
+		flags = tabwriter.Debug
+	}
 	return tabwriter.NewWriter(
 		w,
 		0,   // Minwidth
 		8,   // Tabwidth
 		3,   // Padding
 		' ', // Padchar
-		0,   // Flags
+		flags,
 	)
 }
 

--- a/internal/view/render.go
+++ b/internal/view/render.go
@@ -39,7 +39,7 @@ func NewHumanRenderer(view *View) *HumanRenderer {
 // Render renders a DNS record in human-readable format to the output stream.
 func (v *HumanRenderer) Render(domain string, record dns.RR) {
 	humanReadable := formatRecord(domain, record)
-	v.view.Stream.Writer.Write([]byte(humanReadable))
+	v.view.Stream.Writer.Write([]byte(humanReadable + "\n"))
 }
 
 // JSONRenderer for rendering JSON output.

--- a/internal/view/render.go
+++ b/internal/view/render.go
@@ -39,7 +39,7 @@ func NewHumanRenderer(view *View) *HumanRenderer {
 // Render renders a DNS record in human-readable format to the output stream.
 func (v *HumanRenderer) Render(domain string, record dns.RR) {
 	humanReadable := formatRecord(domain, record)
-	v.view.Stream.Writer.Write([]byte(humanReadable + "\n"))
+	v.view.Stream.Writer.Write([]byte(humanReadable))
 }
 
 // JSONRenderer for rendering JSON output.


### PR DESCRIPTION
Alternative implementation to #19

### Background
This prototype addresses the flaky tab writing issues caused by relying on a regular os.File writer along with our existing tab-based formatting. The output is now handled by a `tabwriter.Writer` from the `text/tabwriter` package, which integrates with the existing view/stream mechanism as it implements the `io.Writer` interface too. The `tabwriter` package acts as a write filter, translating tabbed input columns into proper aligned text for consistent and reliable formatting.

### Debugging
In 1727fac, I added support for debugging the tab writer. When the `debug` flag is set, it prints a vertical bar `('|')` between columns after formatting, and any discarded columns appear as zero-width columns `("||")`.

```console
A      |example.com.   |37m46s      |93.184.215.14
NS     |example.com.   |21h17m02s   |a.iana-servers.net.
NS     |example.com.   |21h17m02s   |b.iana-servers.net.
SOA    |example.com.   |01h00m00s   |ns.icann.org. noc.dns.icann.org.
MX     |example.com.   |21h47m50s   |0 .
TXT    |example.com.   |21h25m07s   |v=spf1 -all
TXT    |example.com.   |21h25m07s   |wgyf8z8cgvm2qmxpnbnldrcltvk4xqfn
AAAA   |example.com.   |18m57s      |2606:2800:21f:cb07:6820:80da:af6b:8b2c
```

### To be considered
FWIW, it might be worth considering moving the tab writer implementation down into the rendering logic, as this would make sure that consumers (e.g., tests) inherit all the behavior of the tab writer. On the other hand, the rendering logic is designed to support any writer, so this change might compromise that flexibility.