### PR TITLE
view: improve type assertions and handle stream write errors

### DIFF
--- a/internal/view/json_test.go
+++ b/internal/view/json_test.go
@@ -82,6 +82,9 @@ func testJSONViewOutputEqualsFull(t *testing.T, output string, want []map[string
 			t.Fatal(err)
 		}
 
+		// While we don't control this directly, we can at least ensure that the timestamp
+		// is present and correctly formatted, as expected.
+		// The timestamp is added by the logger, not the JSONView.
 		if timestamp, ok := gotStruct["@timestamp"]; !ok {
 			t.Errorf("message has no timestamp: %#v", gotStruct)
 		} else {
@@ -89,8 +92,12 @@ func testJSONViewOutputEqualsFull(t *testing.T, output string, want []map[string
 			delete(gotStruct, "@timestamp")
 
 			// Verify the timestamp format
-			if _, err := time.Parse(time.RFC3339, timestamp.(string)); err != nil {
-				t.Errorf("error parsing timestamp on line %d: %s", i, err)
+			if str, ok := timestamp.(string); ok {
+				if _, err := time.Parse(time.RFC3339, str); err != nil {
+					t.Errorf("error parsing timestamp on line %d: %s", i, err)
+				}
+			} else {
+				t.Errorf("unexpected type for timestamp on line %d: %T", i, timestamp)
 			}
 		}
 

--- a/internal/view/render.go
+++ b/internal/view/render.go
@@ -39,7 +39,10 @@ func NewHumanRenderer(view *View) *HumanRenderer {
 // Render renders a DNS record in human-readable format to the output stream.
 func (v *HumanRenderer) Render(domain string, record dns.RR) {
 	humanReadable := formatRecord(domain, record)
-	v.view.Stream.Writer.Write([]byte(humanReadable + "\n"))
+	_, err := v.view.Stream.Writer.Write([]byte(humanReadable + "\n"))
+	if err != nil {
+		panic(err)
+	}
 }
 
 // JSONRenderer for rendering JSON output.

--- a/internal/view/render_test.go
+++ b/internal/view/render_test.go
@@ -18,10 +18,13 @@ func TestNewRenderer_human(t *testing.T) {
 	hv := NewRenderer(arguments.ViewHuman, NewView(&b))
 
 	// Check that the view is a HumanRenderer
-	assert.IsType(t, &HumanRenderer{}, hv)
+	humanRenderer, ok := hv.(*HumanRenderer)
+	assert.True(t, ok, "Expected hv to be of type *HumanRenderer")
+
+	assert.IsType(t, &HumanRenderer{}, humanRenderer)
 
 	// Check that the view's stream writer is the same as the buffer
-	assert.Equal(t, &b, hv.(*HumanRenderer).view.Stream.Writer)
+	assert.Equal(t, &b, humanRenderer.view.Stream.Writer)
 }
 
 // TestNewHumanRenderer should simply return a HumanRenderer.
@@ -110,10 +113,11 @@ func TestNewRenderer_JSON(t *testing.T) {
 	jv := NewRenderer(arguments.ViewJSON, NewView(&b))
 
 	// Check that the view is a JSONRenderer
-	assert.IsType(t, &JSONRenderer{}, jv)
+	jsonRenderer, ok := jv.(*JSONRenderer)
+	assert.True(t, ok, "Expected jv to be of type *JSONRenderer")
 
 	// Check that the view's stream writer is the same as the buffer
-	assert.Equal(t, &b, jv.(*JSONRenderer).view.Stream.Writer)
+	assert.Equal(t, &b, jsonRenderer.view.Stream.Writer)
 }
 
 // TestNewJSONRenderer should simply return a JSONRenderer.


### PR DESCRIPTION
This pull request addresses a few things, around type assertions and error handling.

When using the default (human) renderer, we were suppressing errors when writing to the underlying stream. While there’s no perfect way to handle this, panicking ensures that failures don’t go unnoticed.

Apparently, the [forcetypeassert](https://github.com/gostaticanalysis/forcetypeassert) linter wasn’t satisfied with relying on the type assertion from the [assert](https://github.com/stretchr/testify/assert) package and required an explicit type assertion instead.