### PR TITLE
add DNS nameserver resolution from host

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,12 +51,12 @@ var (
   export ZNS_LOG_FILE=/tmp/zns.log
   zns example.com
 `,
-		Version: version,
-		Run: func(cmd *cobra.Command, args []string) {
+		Version:       version,
+		SilenceErrors: true, // We handle errors ourselves.
+		SilenceUsage:  true, // Prevents the automatic rendering of the usage message when an error occurs.
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				fmt.Println("error: provide a domain name")
-				fmt.Println("See 'zns -h' for help and examples")
-				os.Exit(1)
+				return fmt.Errorf("error: domain name is required")
 			}
 
 			var color hclog.ColorOption
@@ -84,8 +84,7 @@ var (
 			if logFile != "" {
 				f, err := os.Create(logFile)
 				if err != nil {
-					fmt.Printf("error: failed to create log file: %v\n", err)
-					os.Exit(1)
+					return fmt.Errorf("error: failed to create log file: %v", err)
 				}
 				defer f.Close()
 				w = view.NewTabWriter(f, debug)
@@ -107,7 +106,7 @@ var (
 				JSONFormat:           json,
 			}).With("@domain", args[0])
 
-			// Log the debug state and current log level
+			// Log the debug state and current log level.
 			logger.Debug("Debug logging enabled", "debug", debug)
 			logger.Debug("Log level", "level", logger.GetLevel())
 
@@ -122,62 +121,56 @@ var (
 			if server == "" {
 				switch runtime.GOOS {
 				case "windows":
-					fmt.Println("error: host DNS nameserver resolution is not supported on Windows. Please specify a DNS nameserver using the --server flag.")
-					os.Exit(1)
+					return fmt.Errorf("error: host DNS nameserver resolution is not supported on Windows; please specify a DNS server using the --server flag")
 				default:
 					logger.Debug(fmt.Sprintf("Resolving DNS nameserver from \"%s\"", resolveConfPath), "path", resolveConfPath)
 
-					// Attempt to retrieve the DNS nameserver from `/etc/resolv.conf`
+					// Attempt to retrieve the DNS nameserver from `/etc/resolv.conf`.
 					conf, err := dns.ClientConfigFromFile(resolveConfPath)
 					if err != nil {
-						fmt.Printf("error: failed to load DNS nameserver configuration from %s: %v\n", resolveConfPath, err)
-						os.Exit(1)
+						return fmt.Errorf("error: failed to read %s: %v", resolveConfPath, err)
 					}
 
 					if len(conf.Servers) == 0 {
-						fmt.Printf("error: no DNS nameservers found in %s\n", resolveConfPath)
-						os.Exit(1)
+						return fmt.Errorf("error: no DNS nameservers found in %s", resolveConfPath)
 					}
 
-					server = conf.Servers[0] // Use the first available DNS nameserver
+					server = conf.Servers[0] // Use the first available DNS nameserver.
 					logger.Debug(fmt.Sprintf("Using DNS nameserver %s", server), "server", server, "path", resolveConfPath)
 				}
 			}
 
-			// Create a new querier
+			// Create a new querier.
 			querier := query.NewQuerier(fmt.Sprintf("%s:53", server), logger)
 
 			logger.Debug("Creating querier", "server", server, "qtype", qtype, "domain", args[0])
 
-			// Prepare query types
+			// Prepare query types.
 			qtypes := make([]uint16, 0, len(query.QueryTypes))
 			for _, qtype := range query.QueryTypes {
 				qtypes = append(qtypes, qtype)
 			}
 
-			// Set specific query type if provided
+			// Set specific query type if provided.
 			if qtype != "" {
 				qtypeInt, ok := query.QueryTypes[strings.ToUpper(qtype)]
 				if !ok {
-					fmt.Printf("error: invalid query type: %s\n", qtype)
-					os.Exit(1)
+					return fmt.Errorf("error: invalid query type: %s", qtype)
 				}
 				qtypes = []uint16{qtypeInt}
 			}
 
-			// Execute the queries
+			// Execute the queries.
 			messages, err := querier.MultiQuery(args[0], qtypes)
 			if err != nil {
 				if merr, ok := err.(*multierror.Error); ok {
-					for _, e := range merr.Errors {
-						fmt.Println(e)
-					}
+					return merr
 				} else {
-					fmt.Println(err)
+					return err
 				}
-				os.Exit(1)
 			}
 
+			// Sort the messages by query type, so the output is consistent.
 			sort.SliceStable(messages, func(i, j int) bool {
 				return messages[i].Question[0].Qtype < messages[j].Question[0].Qtype
 			})
@@ -188,6 +181,8 @@ var (
 				}
 			}
 			w.Flush() // we need to flush the buffer to ensure all data is written to the underlying stream.
+
+			return nil
 		},
 	}
 )
@@ -202,7 +197,12 @@ func init() {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		if merr, ok := err.(*multierror.Error); ok {
+			for _, e := range merr.Errors {
+				fmt.Fprintln(os.Stderr, e)
+			}
+		} else {
+			fmt.Fprintln(os.Stderr, err)
+		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,7 +141,7 @@ var (
 			}
 
 			// Create a new querier.
-			querier := query.NewQuerier(fmt.Sprintf("%s:53", server), logger)
+			querier := query.NewQueryClient(fmt.Sprintf("%s:53", server), logger)
 
 			logger.Debug("Creating querier", "server", server, "qtype", qtype, "domain", args[0])
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -22,25 +22,17 @@ var (
 	}
 )
 
-// Querier is an interface for querying DNS records.
-type Querier interface {
-	Query(domain string, qtype uint16) (*dns.Msg, error)
-	MultiQuery(domain string, qtypes []uint16) ([]*dns.Msg, error)
-}
-
-// Query implements the Querier interface.
-type Query struct {
+type QueryClient struct {
 	Server string
 	hclog.Logger
 }
 
-// NewQuerier creates a new Querier with the specified server.
-func NewQuerier(server string, logger hclog.Logger) Querier {
-	return &Query{Server: server, Logger: logger}
+func NewQueryClient(server string, logger hclog.Logger) *QueryClient {
+	return &QueryClient{Server: server, Logger: logger}
 }
 
 // MultiQuery performs DNS queries for multiple types concurrently.
-func (q *Query) MultiQuery(domain string, qtypes []uint16) ([]*dns.Msg, error) {
+func (q *QueryClient) MultiQuery(domain string, qtypes []uint16) ([]*dns.Msg, error) {
 	var errors *multierror.Error
 	var wg sync.WaitGroup
 	var mu sync.Mutex
@@ -65,7 +57,7 @@ func (q *Query) MultiQuery(domain string, qtypes []uint16) ([]*dns.Msg, error) {
 }
 
 // Query performs the DNS query and returns the response and any error encountered.
-func (q *Query) Query(domain string, qtype uint16) (*dns.Msg, error) {
+func (q *QueryClient) Query(domain string, qtype uint16) (*dns.Msg, error) {
 	msg := new(dns.Msg)
 	msg.SetQuestion(dns.Fqdn(domain), qtype)
 


### PR DESCRIPTION
Closes #34

This change enables DNS nameserver resolution by reading the system’s host configuration, specifically `/etc/resolv.conf` on Unix-like systems. On Windows, dynamic DNS resolution is not yet supported, and users are prompted to explicitly specify a DNS nameserver using the `--server` flag. We acknowledge that this limits the developer experience for our Windows users, but we prioritize transparency and integrity by ensuring that the host system configuration is respected first.