### PR TITLE
query: add tests

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,11 +106,9 @@ var (
 				JSONFormat:           json,
 			}).With("@domain", args[0])
 
-			// Log the debug state and current log level.
 			logger.Debug("Debug logging enabled", "debug", debug)
 			logger.Debug("Log level", "level", logger.GetLevel())
 
-			// Log the arguments and flags
 			logger.Debug("Args", "args", args)
 			logger.Debug("Flags", "server", server, "qtype", qtype, "debug", debug)
 
@@ -140,18 +138,17 @@ var (
 				}
 			}
 
-			// Create a new querier.
 			querier := query.NewQueryClient(fmt.Sprintf("%s:53", server), logger)
 
 			logger.Debug("Creating querier", "server", server, "qtype", qtype, "domain", args[0])
 
-			// Prepare query types.
+			// Create a slice of supported query types to query.
 			qtypes := make([]uint16, 0, len(query.QueryTypes))
 			for _, qtype := range query.QueryTypes {
 				qtypes = append(qtypes, qtype)
 			}
 
-			// Set specific query type if provided.
+			// Filter down to the specified query type, if provided.
 			if qtype != "" {
 				qtypeInt, ok := query.QueryTypes[strings.ToUpper(qtype)]
 				if !ok {
@@ -160,7 +157,6 @@ var (
 				qtypes = []uint16{qtypeInt}
 			}
 
-			// Execute the queries.
 			messages, err := querier.MultiQuery(args[0], qtypes)
 			if err != nil {
 				if merr, ok := err.(*multierror.Error); ok {

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -153,12 +153,13 @@ func TestQueryClient_MultiQuery_TypeAssert_MultiError(t *testing.T) {
 	// Because MultiQuery returns a multierror.Error, we assert that the error is of that type.
 	assert.IsType(t, &multierror.Error{}, err)
 
-	// We also assert that the error contains two errors, as we are querying two different types.
-	assert.Equal(t, 2, len(err.(*multierror.Error).Errors))
+	// We can then type assert the error to a *multierror.Error and introspect the individual errors.
+	if err, ok := err.(*multierror.Error); ok {
+		// Assert that two errors are returned (one for each query type).
+		assert.Equal(t, 2, len(err.Errors))
 
-	// Similarly, we can assert the error messages.
-	for _, e := range err.(*multierror.Error).Errors {
-		assert.NotNil(t, e)
-		assert.Equal(t, "it's always DNS", e.Error())
+		for _, e := range err.Errors {
+			assert.Equal(t, "it's always DNS", e.Error())
+		}
 	}
 }

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -1,0 +1,164 @@
+package query
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+)
+
+// MockDNSClient is a mock DNS client used for testing purposes.
+// It is used to override the Exchange method to capture and introspect the DNS query.
+type MockDNSClient struct {
+	// ReceivedDomain stores the domain name extracted from the request.
+	// This is used to verify that the correct domain name is passed to the underlying DNS client.
+	ReceivedDomain string
+
+	// QueryType stores the DNS query type (e.g., A, MX) extracted from the request.
+	// This is used to verify that the correct query type is passed to the underlying DNS client.
+	QueryType uint16
+}
+
+func (m *MockDNSClient) Exchange(req *dns.Msg, addr string) (*dns.Msg, time.Duration, error) {
+	// If the request contains a question, capture the domain name and query type.
+	if len(req.Question) > 0 {
+		m.ReceivedDomain = req.Question[0].Name
+		m.QueryType = req.Question[0].Qtype
+	}
+
+	// Return a mock response with a fixed round-trip time and no error.
+	return &dns.Msg{}, time.Microsecond * 42, nil
+}
+
+// MockDNSClientWithError is a mock DNS client used for testing purposes.
+// It is used to override the Exchange method to return an error.
+type MockDNSClientWithError struct{}
+
+func (m *MockDNSClientWithError) Exchange(req *dns.Msg, addr string) (*dns.Msg, time.Duration, error) {
+	return &dns.Msg{}, time.Microsecond * 42, fmt.Errorf("it's always DNS")
+}
+
+func TestQueryClient_Query(t *testing.T) {
+	// Use a null logger to suppress log output during testing.
+	client := NewQueryClient("8.8.8.8", hclog.NewNullLogger())
+
+	mockDNSClient := &MockDNSClient{}
+	client.Client = mockDNSClient
+
+	_, err := client.query("example.com", dns.TypeA)
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, "example.com.", mockDNSClient.ReceivedDomain)
+	assert.Equal(t, dns.TypeA, mockDNSClient.QueryType)
+}
+
+func TestQueryClient_Query_Domain(t *testing.T) {
+	// Use a null logger to suppress log output during testing.
+	client := NewQueryClient("1.1.1.1", hclog.NewNullLogger())
+
+	mockDNSClient := &MockDNSClient{}
+	client.Client = mockDNSClient
+
+	_, err := client.query("abc.xyz", dns.TypeA)
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, "abc.xyz.", mockDNSClient.ReceivedDomain)
+}
+
+func TestQueryClient_Query_QueryType(t *testing.T) {
+	// Use a null logger to suppress log output during testing.
+	client := NewQueryClient("1.1.1.1", hclog.NewNullLogger())
+
+	mockDNSClient := &MockDNSClient{}
+	client.Client = mockDNSClient
+
+	_, err := client.query("abc.xyz", dns.TypeCNAME)
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, dns.TypeCNAME, mockDNSClient.QueryType)
+}
+
+func TestQueryClient_Query_Error(t *testing.T) {
+	// Use a null logger to suppress log output during testing.
+	client := NewQueryClient("8.8.8.8", hclog.NewNullLogger())
+
+	mockDNSClientWithError := &MockDNSClientWithError{}
+	client.Client = mockDNSClientWithError
+
+	_, err := client.query("example.com", dns.TypeA)
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "it's always DNS", err.Error())
+}
+
+func TestQueryClient_MultiQuery(t *testing.T) {
+	// Use a null logger to suppress log output during testing.
+	client := NewQueryClient("8.8.8.8", hclog.NewNullLogger())
+
+	mockDNSClient := &MockDNSClient{}
+	client.Client = mockDNSClient
+
+	resp, err := client.MultiQuery("example.com", []uint16{dns.TypeA, dns.TypeMX})
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, "example.com.", mockDNSClient.ReceivedDomain)
+	assert.Equal(t, 2, len(resp))
+}
+
+func TestQueryClient_MultiQuery_Domain(t *testing.T) {
+	// Use a null logger to suppress log output during testing.
+	client := NewQueryClient("1.1.1.1", hclog.NewNullLogger())
+
+	mockDNSClient := &MockDNSClient{}
+	client.Client = mockDNSClient
+
+	_, err := client.MultiQuery("abc.xyz", []uint16{dns.TypeA, dns.TypeMX})
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, "abc.xyz.", mockDNSClient.ReceivedDomain)
+}
+
+func TestQueryClient_MultiQuery_Error(t *testing.T) {
+	// Use a null logger to suppress log output during testing.
+	client := NewQueryClient("1.1.1.1", hclog.NewNullLogger())
+
+	mockDNSClientWithError := &MockDNSClientWithError{}
+	client.Client = mockDNSClientWithError
+
+	_, err := client.MultiQuery("1", []uint16{dns.TypeA, dns.TypeMX})
+
+	assert.NotNil(t, err)
+}
+
+func TestQueryClient_MultiQuery_TypeAssert_MultiError(t *testing.T) {
+	// Use a null logger to suppress log output during testing.
+	client := NewQueryClient("1.1.1.1", hclog.NewNullLogger())
+
+	mockDNSClientWithError := &MockDNSClientWithError{}
+	client.Client = mockDNSClientWithError
+
+	_, err := client.MultiQuery("1", []uint16{dns.TypeA, dns.TypeMX})
+
+	assert.NotNil(t, err)
+
+	// Because MultiQuery returns a multierror.Error, we assert that the error is of that type.
+	assert.IsType(t, &multierror.Error{}, err)
+
+	// We also assert that the error contains two errors, as we are querying two different types.
+	assert.Equal(t, 2, len(err.(*multierror.Error).Errors))
+
+	// Similarly, we can assert the error messages.
+	for _, e := range err.(*multierror.Error).Errors {
+		assert.NotNil(t, e)
+		assert.Equal(t, "it's always DNS", e.Error())
+	}
+}


### PR DESCRIPTION
This pull request introduces tests to introspect the domain, query types, and errors when querying through the `Query` and `MultiQuery` methods. By using the `DNSClient` interface, we're able to mock the underlying query mechanism and simulate sending a real DNS question without needing to query an actual server.