### PR TITLE
query: initialize the dns client correctly

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,7 +138,7 @@ var (
 				}
 			}
 
-			querier := query.NewQueryClient(fmt.Sprintf("%s:53", server), logger)
+			querier := query.NewQueryClient(fmt.Sprintf("%s:53", server), new(dns.Client), logger)
 
 			logger.Debug("Creating querier", "server", server, "qtype", qtype, "domain", args[0])
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -33,8 +33,14 @@ type QueryClient struct {
 	hclog.Logger
 }
 
-func NewQueryClient(server string, logger hclog.Logger) *QueryClient {
-	return &QueryClient{Server: server, Logger: logger}
+// NewQueryClient initializes a QueryClient with the given DNS server, client, and logger.
+// The provided client must implement the Exchange method for DNS queries.
+func NewQueryClient(server string, client DNSClient, logger hclog.Logger) *QueryClient {
+	return &QueryClient{
+		Server: server,
+		Client: client,
+		Logger: logger,
+	}
 }
 
 // MultiQuery performs DNS queries for multiple types concurrently.

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -55,19 +55,19 @@ func TestQueryClient_Query(t *testing.T) {
 
 func TestQueryClient_Query_Domain(t *testing.T) {
 	mockDNSClient := &MockDNSClient{}
-	client := NewQueryClient("1.1.1.1", mockDNSClient, hclog.NewNullLogger())
+	client := NewQueryClient("8.8.8.8", mockDNSClient, hclog.NewNullLogger())
 
-	_, err := client.query("abc.xyz", dns.TypeA)
+	_, err := client.query("example.com", dns.TypeA)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "abc.xyz.", mockDNSClient.ReceivedDomain)
+	assert.Equal(t, "example.com.", mockDNSClient.ReceivedDomain)
 }
 
 func TestQueryClient_Query_QueryType(t *testing.T) {
 	mockDNSClient := &MockDNSClient{}
-	client := NewQueryClient("1.1.1.1", mockDNSClient, hclog.NewNullLogger())
+	client := NewQueryClient("8.8.8.8", mockDNSClient, hclog.NewNullLogger())
 
-	_, err := client.query("abc.xyz", dns.TypeCNAME)
+	_, err := client.query("example.com", dns.TypeCNAME)
 
 	assert.NoError(t, err)
 	assert.Equal(t, dns.TypeCNAME, mockDNSClient.QueryType)
@@ -96,28 +96,28 @@ func TestQueryClient_MultiQuery(t *testing.T) {
 
 func TestQueryClient_MultiQuery_Domain(t *testing.T) {
 	mockDNSClient := &MockDNSClient{}
-	client := NewQueryClient("1.1.1.1", mockDNSClient, hclog.NewNullLogger())
+	client := NewQueryClient("8.8.8.8", mockDNSClient, hclog.NewNullLogger())
 
-	_, err := client.MultiQuery("abc.xyz", []uint16{dns.TypeA, dns.TypeMX})
+	_, err := client.MultiQuery("example.com", []uint16{dns.TypeA, dns.TypeMX})
 
 	assert.NoError(t, err)
-	assert.Equal(t, "abc.xyz.", mockDNSClient.ReceivedDomain)
+	assert.Equal(t, "example.com.", mockDNSClient.ReceivedDomain)
 }
 
 func TestQueryClient_MultiQuery_Error(t *testing.T) {
 	mockDNSClientWithError := &MockDNSClientWithError{}
-	client := NewQueryClient("1.1.1.1", mockDNSClientWithError, hclog.NewNullLogger())
+	client := NewQueryClient("8.8.8.8", mockDNSClientWithError, hclog.NewNullLogger())
 
-	_, err := client.MultiQuery("1", []uint16{dns.TypeA, dns.TypeMX})
+	_, err := client.MultiQuery("example.com", []uint16{dns.TypeA, dns.TypeMX})
 
 	assert.Error(t, err)
 }
 
 func TestQueryClient_MultiQuery_TypeAssert_MultiError(t *testing.T) {
 	mockDNSClientWithError := &MockDNSClientWithError{}
-	client := NewQueryClient("1.1.1.1", mockDNSClientWithError, hclog.NewNullLogger())
+	client := NewQueryClient("8.8.8.8", mockDNSClientWithError, hclog.NewNullLogger())
 
-	_, err := client.MultiQuery("1", []uint16{dns.TypeA, dns.TypeMX})
+	_, err := client.MultiQuery("example.com", []uint16{dns.TypeA, dns.TypeMX})
 
 	assert.Error(t, err)
 	assert.IsType(t, &multierror.Error{}, err)

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -43,121 +43,87 @@ func (m *MockDNSClientWithError) Exchange(req *dns.Msg, addr string) (*dns.Msg, 
 }
 
 func TestQueryClient_Query(t *testing.T) {
-	// Use a null logger to suppress log output during testing.
-	client := NewQueryClient("8.8.8.8", hclog.NewNullLogger())
-
 	mockDNSClient := &MockDNSClient{}
-	client.Client = mockDNSClient
+	client := NewQueryClient("8.8.8.8", mockDNSClient, hclog.NewNullLogger())
 
 	_, err := client.query("example.com", dns.TypeA)
 
-	assert.Nil(t, err)
-
+	assert.NoError(t, err)
 	assert.Equal(t, "example.com.", mockDNSClient.ReceivedDomain)
 	assert.Equal(t, dns.TypeA, mockDNSClient.QueryType)
 }
 
 func TestQueryClient_Query_Domain(t *testing.T) {
-	// Use a null logger to suppress log output during testing.
-	client := NewQueryClient("1.1.1.1", hclog.NewNullLogger())
-
 	mockDNSClient := &MockDNSClient{}
-	client.Client = mockDNSClient
+	client := NewQueryClient("1.1.1.1", mockDNSClient, hclog.NewNullLogger())
 
 	_, err := client.query("abc.xyz", dns.TypeA)
 
-	assert.Nil(t, err)
-
+	assert.NoError(t, err)
 	assert.Equal(t, "abc.xyz.", mockDNSClient.ReceivedDomain)
 }
 
 func TestQueryClient_Query_QueryType(t *testing.T) {
-	// Use a null logger to suppress log output during testing.
-	client := NewQueryClient("1.1.1.1", hclog.NewNullLogger())
-
 	mockDNSClient := &MockDNSClient{}
-	client.Client = mockDNSClient
+	client := NewQueryClient("1.1.1.1", mockDNSClient, hclog.NewNullLogger())
 
 	_, err := client.query("abc.xyz", dns.TypeCNAME)
 
-	assert.Nil(t, err)
-
+	assert.NoError(t, err)
 	assert.Equal(t, dns.TypeCNAME, mockDNSClient.QueryType)
 }
 
 func TestQueryClient_Query_Error(t *testing.T) {
-	// Use a null logger to suppress log output during testing.
-	client := NewQueryClient("8.8.8.8", hclog.NewNullLogger())
-
 	mockDNSClientWithError := &MockDNSClientWithError{}
-	client.Client = mockDNSClientWithError
+	client := NewQueryClient("8.8.8.8", mockDNSClientWithError, hclog.NewNullLogger())
 
 	_, err := client.query("example.com", dns.TypeA)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "it's always DNS", err.Error())
 }
 
 func TestQueryClient_MultiQuery(t *testing.T) {
-	// Use a null logger to suppress log output during testing.
-	client := NewQueryClient("8.8.8.8", hclog.NewNullLogger())
-
 	mockDNSClient := &MockDNSClient{}
-	client.Client = mockDNSClient
+	client := NewQueryClient("8.8.8.8", mockDNSClient, hclog.NewNullLogger())
 
 	resp, err := client.MultiQuery("example.com", []uint16{dns.TypeA, dns.TypeMX})
 
-	assert.Nil(t, err)
-
+	assert.NoError(t, err)
 	assert.Equal(t, "example.com.", mockDNSClient.ReceivedDomain)
-	assert.Equal(t, 2, len(resp))
+	assert.Len(t, resp, 2)
 }
 
 func TestQueryClient_MultiQuery_Domain(t *testing.T) {
-	// Use a null logger to suppress log output during testing.
-	client := NewQueryClient("1.1.1.1", hclog.NewNullLogger())
-
 	mockDNSClient := &MockDNSClient{}
-	client.Client = mockDNSClient
+	client := NewQueryClient("1.1.1.1", mockDNSClient, hclog.NewNullLogger())
 
 	_, err := client.MultiQuery("abc.xyz", []uint16{dns.TypeA, dns.TypeMX})
 
-	assert.Nil(t, err)
-
+	assert.NoError(t, err)
 	assert.Equal(t, "abc.xyz.", mockDNSClient.ReceivedDomain)
 }
 
 func TestQueryClient_MultiQuery_Error(t *testing.T) {
-	// Use a null logger to suppress log output during testing.
-	client := NewQueryClient("1.1.1.1", hclog.NewNullLogger())
-
 	mockDNSClientWithError := &MockDNSClientWithError{}
-	client.Client = mockDNSClientWithError
+	client := NewQueryClient("1.1.1.1", mockDNSClientWithError, hclog.NewNullLogger())
 
 	_, err := client.MultiQuery("1", []uint16{dns.TypeA, dns.TypeMX})
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestQueryClient_MultiQuery_TypeAssert_MultiError(t *testing.T) {
-	// Use a null logger to suppress log output during testing.
-	client := NewQueryClient("1.1.1.1", hclog.NewNullLogger())
-
 	mockDNSClientWithError := &MockDNSClientWithError{}
-	client.Client = mockDNSClientWithError
+	client := NewQueryClient("1.1.1.1", mockDNSClientWithError, hclog.NewNullLogger())
 
 	_, err := client.MultiQuery("1", []uint16{dns.TypeA, dns.TypeMX})
 
-	assert.NotNil(t, err)
-
-	// Because MultiQuery returns a multierror.Error, we assert that the error is of that type.
+	assert.Error(t, err)
 	assert.IsType(t, &multierror.Error{}, err)
 
-	// We can then type assert the error to a *multierror.Error and introspect the individual errors.
 	if err, ok := err.(*multierror.Error); ok {
-		// Assert that two errors are returned (one for each query type).
-		assert.Equal(t, 2, len(err.Errors))
-
+		assert.Len(t, err.Errors, 2)
 		for _, e := range err.Errors {
 			assert.Equal(t, "it's always DNS", e.Error())
 		}


### PR DESCRIPTION
The query client was not wired correctly, causing a panic when attempting to call Exchange due to a missing underlying client.