### PR TITLE
add functional tests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,10 @@ issues:
       linters:
         - funlen
 
+    - source: "^func NewRootCommand"
+      linters:
+        - funlen
+
 linters:
   disable-all: true
   enable:

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -152,8 +152,8 @@ func Test_Cmd_LogFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Contains(t, string(logFile), "A       example.com.   1m00s   93.184.216.34")
-	assert.Contains(t, string(logFile), "CNAME   example.com.   1m00s   example.org")
+	assert.Contains(t, string(logFile), "A       example.com.   01m00s   93.184.216.34")
+	assert.Contains(t, string(logFile), "CNAME   example.com.   01m00s   example.org.")
 }
 
 func Test_Cmd_LogFile_Debug(t *testing.T) {
@@ -184,6 +184,6 @@ func Test_Cmd_LogFile_Debug(t *testing.T) {
 	assert.Contains(t, string(logFile), "Querying DNS server: @domain=example.com server=127.0.0.1:53535 domain=example.com qtype=CNAME")
 	assert.Contains(t, string(logFile), "Received DNS response: @domain=example.com server=127.0.0.1:53535 domain=example.com qtype=A rcode=NOERROR")
 	assert.Contains(t, string(logFile), "Received DNS response: @domain=example.com server=127.0.0.1:53535 domain=example.com qtype=CNAME rcode=NOERROR")
-	assert.Contains(t, string(logFile), "A       |example.com.   |1m00s   |93.184.216.34")
-	assert.Contains(t, string(logFile), "CNAME   |example.com.   |1m00s   |example.org")
+	assert.Contains(t, string(logFile), "A       |example.com.   |01m00s   |93.184.216.34")
+	assert.Contains(t, string(logFile), "CNAME   |example.com.   |01m00s   |example.org.")
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -69,7 +69,7 @@ func dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
 		}
 	}
 
-	w.WriteMsg(&msg)
+	_ = w.WriteMsg(&msg)
 }
 
 func Test_Cmd(t *testing.T) {
@@ -131,7 +131,7 @@ func Test_Cmd_Debug(t *testing.T) {
 func Test_Cmd_LogFile(t *testing.T) {
 	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
 
-	file, err := os.CreateTemp("", "zns")
+	file, err := os.CreateTemp(t.TempDir(), "zns")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func Test_Cmd_LogFile(t *testing.T) {
 func Test_Cmd_LogFile_Debug(t *testing.T) {
 	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
 
-	file, err := os.CreateTemp("", "zns")
+	file, err := os.CreateTemp(t.TempDir(), "zns")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	DNSServerPort = 53535
+)
+
+func TestMain(m *testing.M) {
+	go startDNSServer()
+
+	code := m.Run()
+	os.Exit(code)
+}
+
+func startDNSServer() {
+	dns.HandleFunc(".", dnsHandler)
+
+	go func() {
+		err := dns.ListenAndServe(fmt.Sprintf(":%d", DNSServerPort), "udp", nil)
+		if err != nil {
+			log.Fatalf("Failed to start DNS server: %v", err)
+		}
+	}()
+}
+
+func dnsHandler(w dns.ResponseWriter, r *dns.Msg) {
+	msg := dns.Msg{}
+	msg.SetReply(r)
+
+	// Simulate an A record response for "example.com"
+	if len(r.Question) > 0 {
+		q := r.Question[0]
+		if q.Name == "example.com." && q.Qtype == dns.TypeA {
+			// Example A record response
+			a := &dns.A{
+				Hdr: dns.RR_Header{
+					Name:   "example.com.",
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    60,
+				},
+				A: net.ParseIP("93.184.216.34"),
+			}
+			msg.Answer = append(msg.Answer, a)
+		}
+		// Simulate a CNAME record response for "example.com"
+		if q.Name == "example.com." && q.Qtype == dns.TypeCNAME {
+			// Example CNAME record response
+			cname := &dns.CNAME{
+				Hdr: dns.RR_Header{
+					Name:   "example.com.",
+					Rrtype: dns.TypeCNAME,
+					Class:  dns.ClassINET,
+					Ttl:    60,
+				},
+				Target: "example.org.",
+			}
+			msg.Answer = append(msg.Answer, cname)
+		}
+	}
+
+	w.WriteMsg(&msg)
+}
+
+func Test_Cmd(t *testing.T) {
+	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
+
+	rootCmd := NewRootCommand()
+	rootCmd.SetArgs([]string{"example.com", "--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort)})
+
+	err := rootCmd.Execute()
+
+	assert.NoError(t, err)
+}
+
+func Test_Cmd_Error(t *testing.T) {
+	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
+
+	rootCmd := NewRootCommand()
+	rootCmd.SetArgs([]string{"--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort)})
+
+	err := rootCmd.Execute()
+
+	assert.Error(t, err)
+	assert.Equal(t, "error: domain name is required", err.Error())
+}
+
+func Test_Cmd_JSON(t *testing.T) {
+	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
+
+	rootCmd := NewRootCommand()
+	rootCmd.SetArgs([]string{"example.com", "--json", "--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort)})
+
+	err := rootCmd.Execute()
+
+	assert.NoError(t, err)
+}
+
+func Test_Cmd_QueryType(t *testing.T) {
+	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
+
+	rootCmd := NewRootCommand()
+	rootCmd.SetArgs([]string{"example.com", "--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort), "--query-type", "A"})
+
+	err := rootCmd.Execute()
+
+	assert.NoError(t, err)
+}
+
+func Test_Cmd_Debug(t *testing.T) {
+	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
+
+	rootCmd := NewRootCommand()
+	rootCmd.SetArgs([]string{"example.com", "--debug", "--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort), "--query-type", "A"})
+
+	err := rootCmd.Execute()
+
+	assert.NoError(t, err)
+}
+
+func Test_Cmd_LogFile(t *testing.T) {
+	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
+
+	file, err := os.CreateTemp("", "zns")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	t.Setenv("ZNS_LOG_FILE", file.Name())
+
+	rootCmd := NewRootCommand()
+	rootCmd.SetArgs([]string{"example.com", "--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort)})
+
+	err = rootCmd.Execute()
+	assert.NoError(t, err)
+
+	assert.FileExists(t, file.Name())
+
+	logFile, err := os.ReadFile(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Contains(t, string(logFile), "A       example.com.   01m00s   93.184.216.34")
+	assert.Contains(t, string(logFile), "CNAME   example.com.   01m00s   example.org")
+}
+
+func Test_Cmd_LogFile_Debug(t *testing.T) {
+	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
+
+	file, err := os.CreateTemp("", "zns")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	t.Setenv("ZNS_LOG_FILE", file.Name())
+
+	rootCmd := NewRootCommand()
+	rootCmd.SetArgs([]string{"example.com", "--debug", "--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort)})
+
+	err = rootCmd.Execute()
+	assert.NoError(t, err)
+
+	assert.FileExists(t, file.Name())
+
+	logFile, err := os.ReadFile(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Contains(t, string(logFile), "Querying DNS server: @domain=example.com server=127.0.0.01:53535 domain=example.com qtype=A")
+	assert.Contains(t, string(logFile), "Querying DNS server: @domain=example.com server=127.0.0.01:53535 domain=example.com qtype=CNAME")
+	assert.Contains(t, string(logFile), "Received DNS response: @domain=example.com server=127.0.0.01:53535 domain=example.com qtype=A rcode=NOERROR")
+	assert.Contains(t, string(logFile), "Received DNS response: @domain=example.com server=127.0.0.01:53535 domain=example.com qtype=CNAME rcode=NOERROR")
+	assert.Contains(t, string(logFile), "A       |example.com.   |01m00s   |93.184.216.34")
+	assert.Contains(t, string(logFile), "CNAME   |example.com.   |01m00s   |example.org")
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -76,7 +76,7 @@ func Test_Cmd(t *testing.T) {
 	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
 
 	rootCmd := NewRootCommand()
-	rootCmd.SetArgs([]string{"example.com", "--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort)})
+	rootCmd.SetArgs([]string{"example.com", "--server", fmt.Sprintf("127.0.0.1:%d", DNSServerPort)})
 
 	err := rootCmd.Execute()
 
@@ -87,7 +87,7 @@ func Test_Cmd_Error(t *testing.T) {
 	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
 
 	rootCmd := NewRootCommand()
-	rootCmd.SetArgs([]string{"--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort)})
+	rootCmd.SetArgs([]string{"--server", fmt.Sprintf("127.0.0.1:%d", DNSServerPort)})
 
 	err := rootCmd.Execute()
 
@@ -99,7 +99,7 @@ func Test_Cmd_JSON(t *testing.T) {
 	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
 
 	rootCmd := NewRootCommand()
-	rootCmd.SetArgs([]string{"example.com", "--json", "--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort)})
+	rootCmd.SetArgs([]string{"example.com", "--json", "--server", fmt.Sprintf("127.0.0.1:%d", DNSServerPort)})
 
 	err := rootCmd.Execute()
 
@@ -110,7 +110,7 @@ func Test_Cmd_QueryType(t *testing.T) {
 	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
 
 	rootCmd := NewRootCommand()
-	rootCmd.SetArgs([]string{"example.com", "--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort), "--query-type", "A"})
+	rootCmd.SetArgs([]string{"example.com", "--server", fmt.Sprintf("127.0.0.1:%d", DNSServerPort), "--query-type", "A"})
 
 	err := rootCmd.Execute()
 
@@ -121,7 +121,7 @@ func Test_Cmd_Debug(t *testing.T) {
 	t.Setenv("NO_COLOR", "1") // Disable color codes for easier testing
 
 	rootCmd := NewRootCommand()
-	rootCmd.SetArgs([]string{"example.com", "--debug", "--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort), "--query-type", "A"})
+	rootCmd.SetArgs([]string{"example.com", "--debug", "--server", fmt.Sprintf("127.0.0.1:%d", DNSServerPort), "--query-type", "A"})
 
 	err := rootCmd.Execute()
 
@@ -140,7 +140,7 @@ func Test_Cmd_LogFile(t *testing.T) {
 	t.Setenv("ZNS_LOG_FILE", file.Name())
 
 	rootCmd := NewRootCommand()
-	rootCmd.SetArgs([]string{"example.com", "--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort)})
+	rootCmd.SetArgs([]string{"example.com", "--server", fmt.Sprintf("127.0.0.1:%d", DNSServerPort)})
 
 	err = rootCmd.Execute()
 	assert.NoError(t, err)
@@ -152,8 +152,8 @@ func Test_Cmd_LogFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Contains(t, string(logFile), "A       example.com.   01m00s   93.184.216.34")
-	assert.Contains(t, string(logFile), "CNAME   example.com.   01m00s   example.org")
+	assert.Contains(t, string(logFile), "A       example.com.   1m00s   93.184.216.34")
+	assert.Contains(t, string(logFile), "CNAME   example.com.   1m00s   example.org")
 }
 
 func Test_Cmd_LogFile_Debug(t *testing.T) {
@@ -168,7 +168,7 @@ func Test_Cmd_LogFile_Debug(t *testing.T) {
 	t.Setenv("ZNS_LOG_FILE", file.Name())
 
 	rootCmd := NewRootCommand()
-	rootCmd.SetArgs([]string{"example.com", "--debug", "--server", fmt.Sprintf("127.0.0.01:%d", DNSServerPort)})
+	rootCmd.SetArgs([]string{"example.com", "--debug", "--server", fmt.Sprintf("127.0.0.1:%d", DNSServerPort)})
 
 	err = rootCmd.Execute()
 	assert.NoError(t, err)
@@ -180,10 +180,10 @@ func Test_Cmd_LogFile_Debug(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Contains(t, string(logFile), "Querying DNS server: @domain=example.com server=127.0.0.01:53535 domain=example.com qtype=A")
-	assert.Contains(t, string(logFile), "Querying DNS server: @domain=example.com server=127.0.0.01:53535 domain=example.com qtype=CNAME")
-	assert.Contains(t, string(logFile), "Received DNS response: @domain=example.com server=127.0.0.01:53535 domain=example.com qtype=A rcode=NOERROR")
-	assert.Contains(t, string(logFile), "Received DNS response: @domain=example.com server=127.0.0.01:53535 domain=example.com qtype=CNAME rcode=NOERROR")
-	assert.Contains(t, string(logFile), "A       |example.com.   |01m00s   |93.184.216.34")
-	assert.Contains(t, string(logFile), "CNAME   |example.com.   |01m00s   |example.org")
+	assert.Contains(t, string(logFile), "Querying DNS server: @domain=example.com server=127.0.0.1:53535 domain=example.com qtype=A")
+	assert.Contains(t, string(logFile), "Querying DNS server: @domain=example.com server=127.0.0.1:53535 domain=example.com qtype=CNAME")
+	assert.Contains(t, string(logFile), "Received DNS response: @domain=example.com server=127.0.0.1:53535 domain=example.com qtype=A rcode=NOERROR")
+	assert.Contains(t, string(logFile), "Received DNS response: @domain=example.com server=127.0.0.1:53535 domain=example.com qtype=CNAME rcode=NOERROR")
+	assert.Contains(t, string(logFile), "A       |example.com.   |1m00s   |93.184.216.34")
+	assert.Contains(t, string(logFile), "CNAME   |example.com.   |1m00s   |example.org")
 }


### PR DESCRIPTION
This proposes functional tests to validate the wiring and execution of the root command. These tests ensure that all components are correctly integrated and can perform DNS queries end-to-end. To make this work, a local DNS server is initialized in [TestMain](https://pkg.go.dev/testing#hdr-Main), providing a _controlled_ environment for testing. The functional tests verify that command-line arguments, flag parsing, logging, and query execution work as expected.