### PR TITLE
reference homebrew-core install

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ zns is a command-line utility for querying DNS records, displaying them in a hum
 ## Installing
 
 ```sh
-brew install znscli/tap/zns
+brew install zns
 ```
 
 ## Usage


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/208599 adds zns to Homebrew core. Moving forward, we should encourage users to install `zns` via Homebrew core for a better installation experience.