### PR TITLE
Improve port appending

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -138,12 +138,10 @@ func NewRootCommand() *cobra.Command {
 				}
 			}
 
-			// If the server address does not already include a port,
-			// append the default DNS port (53) to it.
-			if !strings.Contains(server, ":") {
+			// If the server address doesn't already end with :53, append the default DNS port.
+			if !strings.HasSuffix(server, ":53") {
 				server = fmt.Sprintf("%s:53", server)
 			}
-
 			querier := query.NewQueryClient(server, new(dns.Client), logger)
 
 			logger.Debug("Creating querier", "server", server, "qtype", qtype, "domain", args[0])


### PR DESCRIPTION
If dynamic name server resolution returns an IPv6 address, the current port appending logic will break, as IPv6 addresses use colons to separate hextets, and may already contain colons.