### PR TITLE
fix: properly format IPv6 DNS server addresses when appending port

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"runtime"
 	"sort"
@@ -28,6 +29,20 @@ var (
 	server  string
 	qtype   string
 )
+
+// EnsureDNSAddress formats the DNS server address properly.
+func EnsureDNSAddress(server string) string {
+    if strings.Contains(server, "]") || strings.Contains(server, ":") && net.ParseIP(server) == nil {
+        return server
+    }
+
+    ip := net.ParseIP(server)
+    if ip != nil && ip.To4() == nil { // It's IPv6 (and not IPv4)
+        return "[" + server + "]:53"
+    }
+    // Otherwise, assume IPv4 or hostname, so append port normally.
+    return server + ":53"
+}
 
 func NewRootCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -138,11 +153,7 @@ func NewRootCommand() *cobra.Command {
 				}
 			}
 
-			// If the server address does not already include a port,
-			// append the default DNS port (53) to it.
-			if !strings.Contains(server, ":") {
-				server = fmt.Sprintf("%s:53", server)
-			}
+			server = EnsureDNSAddress(server)
 
 			querier := query.NewQueryClient(server, new(dns.Client), logger)
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -187,3 +187,22 @@ func Test_Cmd_LogFile_Debug(t *testing.T) {
 	assert.Contains(t, string(logFile), "A       |example.com.   |01m00s   |93.184.216.34")
 	assert.Contains(t, string(logFile), "CNAME   |example.com.   |01m00s   |example.org.")
 }
+
+func TestEnsureDNSAddress(t *testing.T) {
+    testCases := []struct {
+        input    string
+        expected string
+    }{
+        {"127.0.0.1", "127.0.0.1:53"},
+        {"2001:558:feed::1", "[2001:558:feed::1]:53"},
+        {"[2001:558:feed::1]:53", "[2001:558:feed::1]:53"},
+        {"example.com", "example.com:53"},
+    }
+
+    for _, tc := range testCases {
+        t.Run(fmt.Sprintf("input=%s", tc.input), func(t *testing.T) {
+            result := EnsureDNSAddress(tc.input)
+            assert.Equal(t, tc.expected, result)
+        })
+    }
+}


### PR DESCRIPTION
closes #49

## before

```
$ ./zns example.com
dial udp: address 2001:558:feed::1:53: too many colons in address
dial udp: address 2001:558:feed::1:53: too many colons in address
dial udp: address 2001:558:feed::1:53: too many colons in address
dial udp: address 2001:558:feed::1:53: too many colons in address
dial udp: address 2001:558:feed::1:53: too many colons in address
dial udp: address 2001:558:feed::1:53: too many colons in address
dial udp: address 2001:558:feed::1:53: too many colons in address
dial udp: address 2001:558:feed::1:53: too many colons in address
```

## after

```
$ ./zns example.com
A      example.com.   01m29s      96.7.128.198
A      example.com.   01m29s      23.192.228.80
A      example.com.   01m29s      23.192.228.84
A      example.com.   01m29s      23.215.0.136
A      example.com.   01m29s      23.215.0.138
A      example.com.   01m29s      96.7.128.175
NS     example.com.   24h00m00s   a.iana-servers.net.
NS     example.com.   24h00m00s   b.iana-servers.net.
SOA    example.com.   01h00m00s   ns.icann.org. noc.dns.icann.org.
MX     example.com.   24h00m00s   0 .
TXT    example.com.   24h00m00s   _k2n1y4vw3qtb4skdx9e7dxt97qrmmq9
TXT    example.com.   24h00m00s   v=spf1 -all
AAAA   example.com.   04m51s      2600:1408:ec00:36::1736:7f31
AAAA   example.com.   04m51s      2600:1406:3a00:21::173e:2e65
AAAA   example.com.   04m51s      2600:1406:3a00:21::173e:2e66
AAAA   example.com.   04m51s      2600:1406:bc00:53::b81e:94c8
AAAA   example.com.   04m51s      2600:1406:bc00:53::b81e:94ce
AAAA   example.com.   04m51s      2600:1408:ec00:36::1736:7f24
```