### PR TITLE
README: add MacPorts install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ zns is a command-line utility for querying DNS records, displaying them in a hum
 brew install zns
 ```
 
+```
+# Via MacPorts
+sudo port install zns
+```
+
 ## Usage
 
 ```sh


### PR DESCRIPTION
`zns` has been added to MacPorts: https://ports.macports.org/port/zns/